### PR TITLE
Add Support for Multiple HydratedBloc Instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.4.1
+
+- Update to support optional `id` in cases where there are multiple instances of the same `HydratedBloc`
+- Documentation Updates
+
 # 0.4.0
 
 - Update to bloc `v0.15.0`

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -33,7 +33,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.4.1"
   meta:
     dependency: transitive
     description:

--- a/lib/src/hydrated_bloc.dart
+++ b/lib/src/hydrated_bloc.dart
@@ -14,15 +14,21 @@ abstract class HydratedBloc<Event, State> extends Bloc<Event, State> {
   @override
   State get initialState {
     try {
-      return fromJson(
-        json.decode(
-          storage?.read(this.runtimeType.toString()) as String,
-        ) as Map<String, dynamic>,
-      );
+      final jsonString =
+          storage?.read('${this.runtimeType.toString()}$id') as String;
+      return jsonString?.isNotEmpty == true
+          ? fromJson(json.decode(jsonString) as Map<String, dynamic>)
+          : null;
     } catch (_) {
       return null;
     }
   }
+
+  /// `id` is used to uniquely identify multiple instances of the same `HydratedBloc` type.
+  /// In most cases it is not necessary; however, if you wish to intentionally have multiple instances
+  /// of the same `HydratedBloc`, then you must override `id` and return a unique identifier for each
+  /// `HydratedBloc` instance in order to keep the caches independent of each other.
+  String get id => '';
 
   /// Responsible for converting the `Map<String, dynamic>` representation of the bloc state
   /// into a concrete instance of the bloc state.

--- a/lib/src/hydrated_bloc_delegate.dart
+++ b/lib/src/hydrated_bloc_delegate.dart
@@ -29,7 +29,7 @@ class HydratedBlocDelegate extends BlocDelegate {
       final stateJson = bloc.toJson(state);
       if (stateJson != null) {
         storage.write(
-          bloc.runtimeType.toString(),
+          '${bloc.runtimeType.toString()}${bloc.id}',
           json.encode(stateJson),
         );
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: hydrated_bloc
 description: An extension to the bloc state management library which automatically persists and restores bloc states.
-version: 0.4.0
+version: 0.4.1
 author: Felix Angelov <felangelov@gmail.com>
 homepage: https://github.com/felangel/hydrated_bloc
 

--- a/test/hydrated_bloc_delegate_test.dart
+++ b/test/hydrated_bloc_delegate_test.dart
@@ -46,9 +46,26 @@ void main() {
         nextState: 'nextState',
       );
       Map<String, String> expected = {'nextState': 'json'};
+      when(bloc.id).thenReturn('');
       when(bloc.toJson('nextState')).thenReturn(expected);
       delegate.onTransition(bloc, transition);
       expect(delegate.storage.read('MockBloc'), '{"nextState":"json"}');
+    });
+
+    test(
+        'should call storage.write when onTransition is called using the static build with bloc id',
+        () async {
+      delegate = await HydratedBlocDelegate.build();
+      final transition = Transition(
+        currentState: 'currentState',
+        event: 'event',
+        nextState: 'nextState',
+      );
+      Map<String, String> expected = {'nextState': 'json'};
+      when(bloc.id).thenReturn('A');
+      when(bloc.toJson('nextState')).thenReturn(expected);
+      delegate.onTransition(bloc, transition);
+      expect(delegate.storage.read('MockBlocA'), '{"nextState":"json"}');
     });
 
     test('should call storage.write when onTransition is called', () {
@@ -58,9 +75,24 @@ void main() {
         nextState: 'nextState',
       );
       Map<String, String> expected = {'nextState': 'json'};
+      when(bloc.id).thenReturn('');
       when(bloc.toJson('nextState')).thenReturn(expected);
       delegate.onTransition(bloc, transition);
       verify(storage.write('MockBloc', json.encode(expected))).called(1);
+    });
+
+    test('should call storage.write when onTransition is called with bloc id',
+        () {
+      final transition = Transition(
+        currentState: 'currentState',
+        event: 'event',
+        nextState: 'nextState',
+      );
+      Map<String, String> expected = {'nextState': 'json'};
+      when(bloc.id).thenReturn('A');
+      when(bloc.toJson('nextState')).thenReturn(expected);
+      delegate.onTransition(bloc, transition);
+      verify(storage.write('MockBlocA', json.encode(expected))).called(1);
     });
   });
 }


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
As a developer, if I want to have multiple instances of the same `HydratedBloc` I want to be able to provide an `id` to uniquely identify the bloc instance so that the states are cached independently and don't result in overwrites.

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
None