### PR TITLE
Add HydratedBloc.clear()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.6.0
+
+- Support clearing individual `HydratedBloc` caches ([#21](https://github.com/felangel/hydrated_bloc/issues/21))
+- Documentation and Example Updates
+
 # 0.5.0
 
 - Support for Desktop ([#18](https://github.com/felangel/hydrated_bloc/pull/18))

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -76,9 +76,7 @@ class CounterPage extends StatelessWidget {
             child: FloatingActionButton(
               child: Icon(Icons.delete_forever),
               onPressed: () async {
-                await (BlocSupervisor.delegate as HydratedBlocDelegate)
-                    .storage
-                    .clear();
+                await counterBloc.clear();
                 counterBloc.dispatch(CounterEvent.reset);
               },
             ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -33,7 +33,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.5.0"
+    version: "0.6.0"
   meta:
     dependency: transitive
     description:

--- a/lib/src/hydrated_bloc.dart
+++ b/lib/src/hydrated_bloc.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
@@ -7,7 +8,7 @@ import 'package:bloc/bloc.dart';
 /// based on the persisted state. This allows state to be persisted
 /// across hot restarts as well as complete app restarts.
 abstract class HydratedBloc<Event, State> extends Bloc<Event, State> {
-  final HydratedStorage storage =
+  final HydratedStorage _storage =
       (BlocSupervisor.delegate as HydratedBlocDelegate).storage;
 
   @mustCallSuper
@@ -15,7 +16,7 @@ abstract class HydratedBloc<Event, State> extends Bloc<Event, State> {
   State get initialState {
     try {
       final jsonString =
-          storage?.read('${this.runtimeType.toString()}$id') as String;
+          _storage?.read('${runtimeType.toString()}$id') as String;
       return jsonString?.isNotEmpty == true
           ? fromJson(json.decode(jsonString) as Map<String, dynamic>)
           : null;
@@ -29,6 +30,11 @@ abstract class HydratedBloc<Event, State> extends Bloc<Event, State> {
   /// of the same `HydratedBloc`, then you must override `id` and return a unique identifier for each
   /// `HydratedBloc` instance in order to keep the caches independent of each other.
   String get id => '';
+
+  /// `clear` is used to wipe or invalidate the cache of a `HydratedBloc`.
+  /// Calling `clear` will delete the cached state of the bloc
+  /// but will not modify the current state of the bloc.
+  Future<void> clear() => _storage.delete('${runtimeType.toString()}$id');
 
   /// Responsible for converting the `Map<String, dynamic>` representation of the bloc state
   /// into a concrete instance of the bloc state.

--- a/lib/src/hydrated_bloc_delegate.dart
+++ b/lib/src/hydrated_bloc_delegate.dart
@@ -4,8 +4,6 @@ import 'package:bloc/bloc.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:platform/platform.dart';
 
-/// A specialized `BlocDelegate` which handles persisting state changes
-/// transparently and asynchronously.
 class HydratedBlocDelegate extends BlocDelegate {
   /// Instance of `HydratedStorage` used to manage persisted states.
   final HydratedStorage storage;
@@ -24,6 +22,8 @@ class HydratedBlocDelegate extends BlocDelegate {
     );
   }
 
+  /// A specialized `BlocDelegate` which handles persisting state changes
+  /// transparently and asynchronously.
   HydratedBlocDelegate(this.storage);
 
   @override

--- a/lib/src/hydrated_bloc_storage.dart
+++ b/lib/src/hydrated_bloc_storage.dart
@@ -13,6 +13,9 @@ abstract class HydratedStorage {
   /// Persists key value pair
   Future<void> write(String key, dynamic value);
 
+  /// Deletes key value pair
+  Future<void> delete(String key);
+
   /// Clears all key value pairs from storage
   Future<void> clear();
 }
@@ -62,6 +65,12 @@ class HydratedBlocStorage implements HydratedStorage {
     _storage[key] = value;
     await _file.writeAsString(json.encode(_storage));
     return _storage[key] = value;
+  }
+
+  @override
+  Future<void> delete(String key) async {
+    _storage[key] = null;
+    return await _file.writeAsString(json.encode(_storage));
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: hydrated_bloc
 description: An extension to the bloc state management library which automatically persists and restores bloc states.
-version: 0.5.0
+version: 0.6.0
 author: Felix Angelov <felangelov@gmail.com>
 homepage: https://github.com/felangel/hydrated_bloc
 

--- a/test/hydrated_bloc_storage_test.dart
+++ b/test/hydrated_bloc_storage_test.dart
@@ -128,9 +128,7 @@ void main() {
         hydratedStorage = await HydratedBlocStorage.getInstance(
           FakePlatform(operatingSystem: 'ios'),
         );
-        await Future.wait(<Future<void>>[
-          hydratedStorage.write('CounterBloc', json.encode({"value": 4})),
-        ]);
+        await hydratedStorage.write('CounterBloc', json.encode({"value": 4}));
 
         expect(hydratedStorage.read('CounterBloc'), '{"value":4}');
       });
@@ -141,15 +139,37 @@ void main() {
         hydratedStorage = await HydratedBlocStorage.getInstance(
           FakePlatform(operatingSystem: 'ios'),
         );
-        await Future.wait(<Future<void>>[
-          hydratedStorage.write('CounterBloc', json.encode({"value": 4})),
-        ]);
+        await hydratedStorage.write('CounterBloc', json.encode({"value": 4}));
 
         expect(hydratedStorage.read('CounterBloc'), '{"value":4}');
         await hydratedStorage.clear();
         expect(hydratedStorage.read('CounterBloc'), isNull);
         final file = File('./.hydrated_bloc.json');
         expect(file.existsSync(), false);
+      });
+    });
+
+    group('delete', () {
+      test('does nothing for non-existing key value pair', () async {
+        hydratedStorage = await HydratedBlocStorage.getInstance(
+          FakePlatform(operatingSystem: 'ios'),
+        );
+
+        expect(hydratedStorage.read('CounterBloc'), null);
+        await hydratedStorage.delete('CounterBloc');
+        expect(hydratedStorage.read('CounterBloc'), isNull);
+      });
+
+      test('deletes existing key value pair', () async {
+        hydratedStorage = await HydratedBlocStorage.getInstance(
+          FakePlatform(operatingSystem: 'ios'),
+        );
+        await hydratedStorage.write('CounterBloc', json.encode({"value": 4}));
+
+        expect(hydratedStorage.read('CounterBloc'), '{"value":4}');
+
+        await hydratedStorage.delete('CounterBloc');
+        expect(hydratedStorage.read('CounterBloc'), isNull);
       });
     });
   });

--- a/test/hydrated_bloc_test.dart
+++ b/test/hydrated_bloc_test.dart
@@ -95,6 +95,13 @@ void main() {
       expect(bloc.initialState, 101);
       verify<dynamic>(storage.read('MyHydratedBloc')).called(2);
     });
+
+    group('clear', () {
+      test('calls delete on storage', () async {
+        await bloc.clear();
+        verify(storage.delete('MyHydratedBloc')).called(1);
+      });
+    });
   });
 
   group('MultiHydratedBloc', () {
@@ -127,6 +134,17 @@ void main() {
           .thenReturn(json.encode({'value': 102}));
       expect(multiBlocB.initialState, 102);
       verify<dynamic>(storage.read('MyMultiHydratedBlocB')).called(2);
+    });
+
+    group('clear', () {
+      test('calls delete on storage', () async {
+        await multiBlocA.clear();
+        verify(storage.delete('MyMultiHydratedBlocA')).called(1);
+        verifyNever(storage.delete('MyMultiHydratedBlocB'));
+
+        await multiBlocB.clear();
+        verify(storage.delete('MyMultiHydratedBlocB')).called(1);
+      });
     });
   });
 }


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- Add `HydratedBloc.clear()` which allows developers to wipe out the cached data for a specific `HydratedBloc` (#21)

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
None