### PR TITLE
Saving initial

### DIFF
--- a/lib/src/hydrated_bloc.dart
+++ b/lib/src/hydrated_bloc.dart
@@ -14,7 +14,7 @@ import '../hydrated_bloc.dart';
 abstract class HydratedBloc<Event, State> extends Bloc<Event, State> {
   /// {@macro hydrated_bloc}
   HydratedBloc() {
-    final stateJson = toJson(initialState);
+    final stateJson = toJson(state);
     if (stateJson != null) {
       _storage.write(
         '${runtimeType.toString()}$id',

--- a/lib/src/hydrated_bloc.dart
+++ b/lib/src/hydrated_bloc.dart
@@ -15,8 +15,7 @@ abstract class HydratedBloc<Event, State> extends Bloc<Event, State> {
   @override
   State get initialState {
     try {
-      final jsonString =
-          _storage?.read('${runtimeType.toString()}$id') as String;
+      final jsonString = _storage?.read(storageToken) as String;
       return jsonString?.isNotEmpty == true
           ? fromJson(json.decode(jsonString) as Map<String, dynamic>)
           : null;
@@ -31,10 +30,14 @@ abstract class HydratedBloc<Event, State> extends Bloc<Event, State> {
   /// `HydratedBloc` instance in order to keep the caches independent of each other.
   String get id => '';
 
+  /// `storageToken` is used as registration token for hydrated storage.
+  @nonVirtual
+  String get storageToken => '${runtimeType.toString()}$id';
+
   /// `clear` is used to wipe or invalidate the cache of a `HydratedBloc`.
   /// Calling `clear` will delete the cached state of the bloc
   /// but will not modify the current state of the bloc.
-  Future<void> clear() => _storage.delete('${runtimeType.toString()}$id');
+  Future<void> clear() => _storage.delete(storageToken);
 
   /// Responsible for converting the `Map<String, dynamic>` representation of the bloc state
   /// into a concrete instance of the bloc state.

--- a/lib/src/hydrated_bloc.dart
+++ b/lib/src/hydrated_bloc.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:meta/meta.dart';
 import 'package:flutter/foundation.dart';
 import 'package:bloc/bloc.dart';
 

--- a/lib/src/hydrated_bloc.dart
+++ b/lib/src/hydrated_bloc.dart
@@ -16,10 +16,7 @@ abstract class HydratedBloc<Event, State> extends Bloc<Event, State> {
   HydratedBloc() {
     final stateJson = toJson(state);
     if (stateJson != null) {
-      _storage.write(
-        '${runtimeType.toString()}$id',
-        json.encode(stateJson),
-      );
+      _storage.write(storageToken, json.encode(stateJson));
     }
   }
 

--- a/lib/src/hydrated_bloc_delegate.dart
+++ b/lib/src/hydrated_bloc_delegate.dart
@@ -37,10 +37,7 @@ class HydratedBlocDelegate extends BlocDelegate {
     if (bloc is HydratedBloc) {
       final stateJson = bloc.toJson(state);
       if (stateJson != null) {
-        storage.write(
-          '${bloc.runtimeType.toString()}${bloc.id}',
-          json.encode(stateJson),
-        );
+        storage.write(bloc.storageToken, json.encode(stateJson));
       }
     }
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -123,13 +123,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.5.1"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.8.0+1"
   petitparser:
     dependency: transitive
     description:
@@ -204,7 +197,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.11"
+    version: "0.2.15"
   typed_data:
     dependency: transitive
     description:

--- a/test/hydrated_bloc_delegate_test.dart
+++ b/test/hydrated_bloc_delegate_test.dart
@@ -7,7 +7,9 @@ import 'package:mockito/mockito.dart';
 import 'package:bloc/bloc.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
 
-class MockBloc extends Mock implements HydratedBloc<dynamic, dynamic> {}
+class MockBloc extends Mock implements HydratedBloc<dynamic, dynamic> {
+  String get storageToken => '${runtimeType.toString()}$id';
+}
 
 class MockStorage extends Mock implements HydratedBlocStorage {}
 
@@ -25,11 +27,9 @@ void main() {
       bloc = MockBloc();
     });
 
-    tearDown(() async {
-      final file = File('./.hydrated_bloc.json');
-      if (file.existsSync()) {
-        file.deleteSync();
-      }
+    tearDownAll(() async {
+      delegate = await HydratedBlocDelegate.build();
+      delegate.storage.clear();
     });
 
     test('should call storage.write when onTransition is called', () {


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
Persist `initialState` when initialized.
And it is faithfully initial `state`.
Added `storageToken`. It is used as registration token for hydrated storage.

## Todos
- [x] Tests fixed
- [ ] Tests added
- [x] Documentation


## Impact to Remaining Code Base
This PR will affect:
- lib/src/hydrated_bloc.dart
- lib/src/hydrated_bloc_delegate.dart
- test/hydrated_bloc_delegate_test.dart