### PR TITLE
RuntimeHydratedBloc implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.1.0
+
+- Implement `RuntimeHydratedBloc` that persists the state only during runtime.
+
 # 3.0.0
 
 - Updated to `bloc: ^3.0.0`

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ BlocSupervisor.delegate = MyHydratedBlocDelegate();
 ```
 
 ## Runtime Hydrated Bloc
-In order to persist the state only during the application is running then extend `RuntimeHydratedBloc`. For example: 
+If you want to persist the state only when the application is running, then you should extend `RuntimeHydratedBloc`.
 
 ```dart
 class CounterBloc extends RuntimeHydratedBloc<CounterEvent, CounterState> {

--- a/README.md
+++ b/README.md
@@ -156,3 +156,28 @@ class MyHydratedBlocDelegate extends HydratedBlocDelegate {
 
 BlocSupervisor.delegate = MyHydratedBlocDelegate();
 ```
+
+## Runtime Hydrated Bloc
+In order to persist the state only during the application is running then extend `RuntimeHydratedBloc`. For example: 
+
+```dart
+class CounterBloc extends RuntimeHydratedBloc<CounterEvent, CounterState> {
+  @override
+  CounterState get initialState => super.initialState ?? CounterState(0);
+
+  @override
+  Stream<CounterState> mapEventToState(CounterEvent event) async* {
+    switch (event) {
+      case CounterEvent.decrement:
+        yield CounterState(state.value - 1);
+        break;
+      case CounterEvent.increment:
+        yield CounterState(state.value + 1);
+        break;
+      case CounterEvent.reset:
+        yield CounterState(0);
+        break;
+    }
+  }
+}
+```

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -33,7 +33,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.0"
+    version: "3.1.0"
   meta:
     dependency: transitive
     description:

--- a/lib/hydrated_bloc.dart
+++ b/lib/hydrated_bloc.dart
@@ -3,3 +3,4 @@ library hydrated_bloc;
 export 'src/hydrated_bloc.dart';
 export 'src/hydrated_bloc_delegate.dart';
 export 'src/hydrated_bloc_storage.dart';
+export 'src/runtime_hydrated_bloc.dart';

--- a/lib/src/hydrated_bloc_delegate.dart
+++ b/lib/src/hydrated_bloc_delegate.dart
@@ -12,6 +12,9 @@ class HydratedBlocDelegate extends BlocDelegate {
   /// Instance of `HydratedStorage` used to manage persisted states.
   final HydratedStorage storage;
 
+  /// Instance of a cache map to manage `RuntimeHydratedBloc` persistence.
+  final Map<String, dynamic> runtimeStorage = {};
+
   /// Builds a new instance of `HydratedBlocDelegate` with the
   /// default `HydratedBlocStorage`.
   /// A custom `storageDirectory` can optionally be provided.
@@ -42,6 +45,8 @@ class HydratedBlocDelegate extends BlocDelegate {
           json.encode(stateJson),
         );
       }
+    } else if (bloc is RuntimeHydratedBloc) {
+      runtimeStorage[bloc.storageToken] = state;
     }
   }
 }

--- a/lib/src/runtime_hydrated_bloc.dart
+++ b/lib/src/runtime_hydrated_bloc.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/foundation.dart';
+import 'package:hydrated_bloc/hydrated_bloc.dart';
+import 'package:bloc/bloc.dart';
+import 'package:meta/meta.dart';
+
+/// Specialized `Bloc` which handles initializing the `Bloc` state
+/// based on the persisted state in memory.
+abstract class RuntimeHydratedBloc<Event, State> extends Bloc<Event, State> {
+  final Map<String, dynamic> _runtimeStorage =
+      (BlocSupervisor.delegate as HydratedBlocDelegate).runtimeStorage;
+
+  /// `storageToken` is used as registration token for hydrated storage.
+  @nonVirtual
+  String get storageToken => '${runtimeType.toString()}$id';
+
+  @mustCallSuper
+  @override
+  State get initialState {
+    try {
+      return _runtimeStorage[storageToken] as State;
+    } on dynamic catch (_) {
+      return null;
+    }
+  }
+
+  /// `id` is used to uniquely identify multiple instances of the same `RuntimeHydratedBloc` type.
+  /// In most cases it is not necessary; however, if you wish to intentionally have multiple instances
+  /// of the same `RuntimeHydratedBloc`, then you must override `id` and return a unique identifier for each
+  /// `RuntimeHydratedBloc` instance in order to keep the caches independent of each other.
+  String get id => '';
+
+  /// `clear` is used to wipe or invalidate the cache of a `RuntimeHydratedBloc`.
+  /// Calling `clear` will delete the cached state of the bloc
+  /// but will not modify the current state of the bloc.
+  void clear() => _runtimeStorage.remove(storageToken);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: hydrated_bloc
 description: An extension to the bloc state management library which automatically persists and restores bloc states.
-version: 3.0.0
+version: 3.1.0
 homepage: https://github.com/felangel/hydrated_bloc
 
 environment:

--- a/test/hydrated_bloc_delegate_test.dart
+++ b/test/hydrated_bloc_delegate_test.dart
@@ -9,6 +9,9 @@ import 'package:hydrated_bloc/hydrated_bloc.dart';
 
 class MockBloc extends Mock implements HydratedBloc<dynamic, dynamic> {}
 
+class MockRuntimeHydratedBloc extends Mock
+    implements RuntimeHydratedBloc<dynamic, dynamic> {}
+
 class MockStorage extends Mock implements HydratedBlocStorage {}
 
 void main() {
@@ -18,11 +21,13 @@ void main() {
     MockStorage storage;
     HydratedBlocDelegate delegate;
     MockBloc bloc;
+    MockRuntimeHydratedBloc runtimeHydratedBloc;
 
     setUp(() {
       storage = MockStorage();
       delegate = HydratedBlocDelegate(storage);
       bloc = MockBloc();
+      runtimeHydratedBloc = MockRuntimeHydratedBloc();
     });
 
     tearDown(() async {
@@ -57,6 +62,25 @@ void main() {
       when(bloc.toJson('nextState')).thenReturn(expected);
       delegate.onTransition(bloc, transition);
       verify(storage.write('MockBlocA', json.encode(expected))).called(1);
+    });
+
+    test(
+        'should store in the runtime storage when onTransition is called with runtime bloc',
+        () {
+      final expectedToken = 'dummyToken';
+      final expectedState = 'nextState';
+      final transition = Transition(
+        currentState: 'currentState',
+        event: 'event',
+        nextState: expectedState,
+      );
+      when(runtimeHydratedBloc.storageToken).thenReturn(expectedToken);
+
+      expect(delegate.runtimeStorage, isEmpty);
+
+      delegate.onTransition(runtimeHydratedBloc, transition);
+      expect(delegate.runtimeStorage[expectedToken], expectedState);
+      expect(delegate.runtimeStorage.length, 1);
     });
 
     group('Default Storage Directory', () {

--- a/test/runtime_hydrated_bloc_test.dart
+++ b/test/runtime_hydrated_bloc_test.dart
@@ -1,0 +1,107 @@
+import 'dart:async';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:hydrated_bloc/hydrated_bloc.dart';
+import 'package:bloc/bloc.dart';
+
+class MockHydratedBlocDelegate extends Mock implements HydratedBlocDelegate {}
+
+class MyRuntimeHydratedBloc extends RuntimeHydratedBloc<int, int> {
+  @override
+  int get initialState => super.initialState ?? 0;
+
+  @override
+  Stream<int> mapEventToState(int event) {
+    return null;
+  }
+}
+
+class MyMultiRuntimeHydratedBloc extends RuntimeHydratedBloc<int, int> {
+  final String _id;
+
+  MyMultiRuntimeHydratedBloc(String id) : _id = id;
+
+  @override
+  int get initialState => super.initialState ?? 0;
+
+  @override
+  String get id => _id;
+
+  @override
+  Stream<int> mapEventToState(int event) {
+    return null;
+  }
+}
+
+void main() {
+  MockHydratedBlocDelegate delegate;
+  Map<String, dynamic> runtimeStorage;
+
+  setUp(() {
+    delegate = MockHydratedBlocDelegate();
+    BlocSupervisor.delegate = delegate;
+    runtimeStorage = {};
+
+    when(delegate.runtimeStorage).thenReturn(runtimeStorage);
+  });
+
+  group('RuntimeHydratedBloc', () {
+    MyRuntimeHydratedBloc bloc;
+
+    setUp(() {
+      bloc = MyRuntimeHydratedBloc();
+    });
+
+    test('initialState should return 0 when map is empty', () {
+      expect(bloc.initialState, 0);
+    });
+
+    test('initialState should return 101 when map contains 101', () {
+      runtimeStorage[bloc.storageToken] = 101;
+      expect(bloc.initialState, 101);
+    });
+
+    group('clear', () {
+      test('calls delete map entry', () async {
+        runtimeStorage[bloc.storageToken] = 101;
+        bloc.clear();
+        expect(runtimeStorage[bloc.storageToken], isNull);
+      });
+    });
+  });
+
+  group('MultiRuntimeHydratedBloc', () {
+    MyMultiRuntimeHydratedBloc multiBlocA;
+    MyMultiRuntimeHydratedBloc multiBlocB;
+
+    setUp(() {
+      multiBlocA = MyMultiRuntimeHydratedBloc('A');
+      multiBlocB = MyMultiRuntimeHydratedBloc('B');
+    });
+
+    test('initialState should return 0 when map is empty', () {
+      expect(multiBlocA.initialState, 0);
+      expect(multiBlocB.initialState, 0);
+    });
+
+    test('initialState should return 101/102 when map contains 101/102', () {
+      runtimeStorage[multiBlocA.storageToken] = 101;
+      expect(multiBlocA.initialState, 101);
+
+      runtimeStorage[multiBlocB.storageToken] = 102;
+      expect(multiBlocB.initialState, 102);
+    });
+
+    group('clear', () {
+      test('calls delete map entry', () async {
+        runtimeStorage[multiBlocA.storageToken] = 101;
+        runtimeStorage[multiBlocB.storageToken] = 102;
+        multiBlocA.clear();
+        expect(runtimeStorage[multiBlocA.storageToken], isNull);
+        expect(runtimeStorage[multiBlocB.storageToken], isNotNull);
+        multiBlocB.clear();
+        expect(runtimeStorage[multiBlocB.storageToken], isNull);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
In large and complex applications sometimes you want persist the state only during the runtime. Because UX, optimization or whatever, you do not want to persist in the device memory the state.

The implementation is very simple and I think it makes sense to offer this possibility in this library. Also, in the future the common functionality could be refactored in base/utils class.

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples
