### PR TITLE
fix: invoke onError and continue emitting states when exceptions occur

### DIFF
--- a/lib/src/hydrated_bloc_delegate.dart
+++ b/lib/src/hydrated_bloc_delegate.dart
@@ -39,7 +39,11 @@ class HydratedBlocDelegate extends BlocDelegate {
     if (bloc is HydratedBloc) {
       final stateJson = bloc.toJson(state);
       if (stateJson != null) {
-        storage.write(bloc.storageToken, json.encode(stateJson));
+        try {
+          storage.write(bloc.storageToken, json.encode(stateJson));
+        } on dynamic catch (error, stackTrace) {
+          onError(bloc, error, stackTrace);
+        }
       }
     }
   }


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- Propagate exceptions that occur due to json encoding/decoding or storage read/write to `onError`
- Allow bloc to continue emitting states even if caching exceptions occur (closes #41)

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
Bugfix to be included in v3.1.0