### PR TITLE
fix: upgrade to cubit 0.1.2 to prevent data loss during migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.0.2
+
+- fix: upgrade to `hydrated_cubit ^0.1.2` to prevent data loss during migration.
+
 # 5.0.1
 
 - fix: export `Storage` interface

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: cubit
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0"
+    version: "0.1.2"
   file:
     dependency: transitive
     description:
@@ -89,7 +89,7 @@ packages:
       name: hydrated_cubit
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0"
+    version: "0.1.2"
   intl:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
     sdk: flutter
   hydrated_bloc:
     path: ../
-  flutter_bloc: ^5.0.0-dev.4
+  flutter_bloc: ^5.0.0
   path_provider_fde:
     git:
       url: https://github.com/google/flutter-desktop-embedding

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
     sdk: flutter
   meta: ^1.1.8
   bloc: ^5.0.0
-  hydrated_cubit: ^0.1.0
+  hydrated_cubit: ^0.1.2
   hive: ^1.4.1+1
   synchronized: ^2.2.0
   path_provider: ^1.6.5


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
closes #67 and related to #66 
- upgrade to cubit 0.1.2 to prevent data loss during migration (https://github.com/felangel/cubit/pull/61)