### PR TITLE
fix: excessive storage reads and fromJson invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 5.0.3
+
+- fix: excessive storage reads and `fromJson` invocations
+- chore: upgrade to `hydrated_cubit ^0.1.3`
+- chore: upgrade to `bloc ^5.0.1`
+- docs: minor documentation improvements
+
 # 5.0.2
 
 - fix: upgrade to `hydrated_cubit ^0.1.2` to prevent data loss during migration.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: bloc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0"
+    version: "5.0.1"
   charcode:
     dependency: transitive
     description:
@@ -82,14 +82,14 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "5.0.2"
+    version: "5.0.3"
   hydrated_cubit:
     dependency: transitive
     description:
       name: hydrated_cubit
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2"
+    version: "0.1.3"
   intl:
     dependency: transitive
     description:

--- a/lib/src/hydrated_bloc.dart
+++ b/lib/src/hydrated_bloc.dart
@@ -33,11 +33,11 @@ abstract class HydratedBloc<Event, State> extends Bloc<Event, State> {
     if (_state != null) return _state;
     try {
       final stateJson = storage.read(storageToken);
-      if (stateJson == null) return super.state;
-      return fromJson(Map<String, dynamic>.from(stateJson));
+      if (stateJson == null) return _state = super.state;
+      return _state = fromJson(Map<String, dynamic>.from(stateJson));
     } on dynamic catch (error, stackTrace) {
       onError(error, stackTrace);
-      return super.state;
+      return _state = super.state;
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,10 @@
 name: hydrated_bloc
 description: An extension to the bloc state management library which automatically persists and restores bloc states.
-version: 5.0.2
-homepage: https://github.com/felangel/hydrated_bloc
+version: 5.0.3
+repository: https://github.com/felangel/hydrated_bloc
+issue_tracker: https://github.com/felangel/hydrated_bloc/issues
+homepage: https://bloclibrary.dev
+documentation: https://bloclibrary.dev/#/gettingstarted
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
@@ -10,8 +13,8 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.1.8
-  bloc: ^5.0.0
-  hydrated_cubit: ^0.1.2
+  bloc: ^5.0.1
+  hydrated_cubit: ^0.1.3
   hive: ^1.4.1+1
   synchronized: ^2.2.0
   path_provider: ^1.6.5


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description

- fix: excessive storage reads and `fromJson` invocations
- chore: upgrade to `hydrated_cubit ^0.1.3`
- chore: upgrade to `bloc ^5.0.1`
- docs: minor documentation improvements